### PR TITLE
:sparkles: serve static files if they are not markdown documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ js:
 ---
 ```
 
+## Build
+
+Simply run:
+
+```
+$ go build
+```
+
 ## Usage
 
 ```
@@ -46,6 +54,7 @@ If you have the following structure:
 |-+ docs/
   |-- _index.md
   |-- hello.md
+  |-- image.png
   |-+ foo/
     |-- bar.md
 ```
@@ -59,6 +68,7 @@ $ easymd -h 127.0.0.1 -p 8000 -r ./docs/
 The following URLs will be available:
 
  - http://127.0.0.1:8000/
+ - http://127.0.0.1:8000/image.png
  - http://127.0.0.1:8000/hello/
  - http://127.0.0.1:8000/hello
  - http://127.0.0.1:8000/foo/bar/

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -34,29 +34,33 @@ func Serve(rootDocument string, host net.IP, port int) {
 			}
 		}
 
-		page := document.Page{
-			Params: document.PageParams{
-				Title: "Not Found",
-				Lang:  "en",
-				Meta:  []document.MetaTag{},
-				CSS:   []string{},
-				JS:    []string{},
-			},
-			Content: fmt.Sprintf(
-				`
-					<div class="message is-danger m-5">
-						<div class="message-header"><p>Not Found</p></div>
-						<div class="message-body">%s</div>
-					</div>
-				`,
-				r.URL.Path,
-			),
-		}
+		if path, found := hasStaticFile(rootDocument, r.URL.Path); found {
+			http.ServeFile(w, r, path)
+		} else {
+			page := document.Page{
+				Params: document.PageParams{
+					Title: "Not Found",
+					Lang:  "en",
+					Meta:  []document.MetaTag{},
+					CSS:   []string{},
+					JS:    []string{},
+				},
+				Content: fmt.Sprintf(
+					`
+						<div class="message is-danger m-5">
+							<div class="message-header"><p>Not Found</p></div>
+							<div class="message-body">%s</div>
+						</div>
+					`,
+					r.URL.Path,
+				),
+			}
 
-		w.WriteHeader(http.StatusNotFound)
-		err := page.Render(w)
-		if err != nil {
-			log.Println("ERROR: ", err)
+			w.WriteHeader(http.StatusNotFound)
+			err := page.Render(w)
+			if err != nil {
+				log.Println("ERROR: ", err)
+			}
 		}
 	})
 

--- a/pkg/server/static.go
+++ b/pkg/server/static.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func hasStaticFile(rootDocument string, urlPath string) (string, bool) {
+	documentPath := filepath.Join(rootDocument, strings.TrimSuffix(urlPath, "/"))
+
+	if _, err := os.Stat(documentPath); !os.IsNotExist(err) {
+		return documentPath, true
+	}
+
+	return "", false
+}


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :memo: Add build instructions to README
 - [x] :sparkles: If no markdown document is found for a path, try to serve the static file if it exists
