### PR TITLE
:fire: Remove link element from template

### DIFF
--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -17,7 +17,6 @@ const layout = `
 			<meta {{ .Attribute }}="{{ .Value }}" />
 		{{ end }}
 
-		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" />
 		{{ range .Params.CSS }}
 			<link rel="stylesheet" href="{{ . }}" />
 		{{ end }}


### PR DESCRIPTION
Hi again!

While trying out the `css` feature in the YAML front-matter, I noticed an extra `css` relation in the resulting HTML:

![](https://i.imgur.com/t66Xky8.png)

I'm assuming that line was left there unintentionally 😄

I went ahead and updated the template file 🥷 